### PR TITLE
PS-5578 - added optional parameter to use scrollParent on revert animation

### DIFF
--- a/dist/jquery-ui.js
+++ b/dist/jquery-ui.js
@@ -16561,22 +16561,22 @@ return $.widget( "ui.sortable", $.ui.mouse, {
 				axis = this.options.axis,
 				animation = {};
 
-			var offSetElement = this.options.onRevertUseScrollParent ?
-			  this.placeholder.scrollParent() :
+			var offsetElement = this.options.onRevertUseScrollParent ?
+			  this.scrollParent :
 			  this.offsetParent;
 
 			if ( !axis || axis === "x" ) {
 				animation.left = cur.left - this.offset.parent.left - this.margins.left +
-					( offSetElement[ 0 ] === this.document[ 0 ].body ?
+					( offsetElement[ 0 ] === this.document[ 0 ].body ?
 						0 :
-						offSetElement[ 0 ].scrollLeft
+						offsetElement[ 0 ].scrollLeft
 					);
 			}
 			if ( !axis || axis === "y" ) {
 				animation.top = cur.top - this.offset.parent.top - this.margins.top +
-					( offSetElement[ 0 ] === this.document[ 0 ].body ?
+					( offsetElement[ 0 ] === this.document[ 0 ].body ?
 						0 :
-						offSetElement[ 0 ].scrollTop
+						offsetElement[ 0 ].scrollTop
 					);
 			}
 			this.reverting = true;

--- a/dist/jquery-ui.js
+++ b/dist/jquery-ui.js
@@ -1,4 +1,4 @@
-/*! jQuery UI - v1.12.2-pre - 2018-03-08
+/*! jQuery UI - v1.12.2-pre1 - 2020-01-13
 * http://jqueryui.com
 * Includes: core.js, widget.js, mouse.js, draggable.js, droppable.js, resizable.js, selectable.js, sortable.js, effect.js, data.js, disable-selection.js, effect-blind.js, effect-bounce.js, effect-clip.js, effect-drop.js, effect-explode.js, effect-fade.js, effect-fold.js, effect-highlight.js, effect-puff.js, effect-pulsate.js, effect-scale.js, effect-shake.js, effect-size.js, effect-slide.js, effect-transfer.js, escape-selector.js, focusable.js, form-reset-mixin.js, form.js, datepicker-af.js, datepicker-ar-DZ.js, datepicker-ar.js, datepicker-az.js, datepicker-be.js, datepicker-bg.js, datepicker-bs.js, datepicker-ca.js, datepicker-cs.js, datepicker-cy-GB.js, datepicker-da.js, datepicker-de.js, datepicker-el.js, datepicker-en-AU.js, datepicker-en-GB.js, datepicker-en-NZ.js, datepicker-eo.js, datepicker-es.js, datepicker-et.js, datepicker-eu.js, datepicker-fa.js, datepicker-fi.js, datepicker-fo.js, datepicker-fr-CA.js, datepicker-fr-CH.js, datepicker-fr.js, datepicker-gl.js, datepicker-he.js, datepicker-hi.js, datepicker-hr.js, datepicker-hu.js, datepicker-hy.js, datepicker-id.js, datepicker-is.js, datepicker-it-CH.js, datepicker-it.js, datepicker-ja.js, datepicker-ka.js, datepicker-kk.js, datepicker-km.js, datepicker-ko.js, datepicker-ky.js, datepicker-lb.js, datepicker-lt.js, datepicker-lv.js, datepicker-mk.js, datepicker-ml.js, datepicker-ms.js, datepicker-nb.js, datepicker-nl-BE.js, datepicker-nl.js, datepicker-nn.js, datepicker-no.js, datepicker-pl.js, datepicker-pt-BR.js, datepicker-pt.js, datepicker-rm.js, datepicker-ro.js, datepicker-ru.js, datepicker-sk.js, datepicker-sl.js, datepicker-sq.js, datepicker-sr-SR.js, datepicker-sr.js, datepicker-sv.js, datepicker-ta.js, datepicker-th.js, datepicker-tj.js, datepicker-tr.js, datepicker-uk.js, datepicker-vi.js, datepicker-zh-CN.js, datepicker-zh-HK.js, datepicker-zh-TW.js, ie.js, jquery-1-7.js, keycode.js, labels.js, plugin.js, position.js, safe-active-element.js, safe-blur.js, scroll-parent.js, tabbable.js, unique-id.js, version.js, accordion.js, autocomplete.js, button.js, checkboxradio.js, controlgroup.js, datepicker.js, dialog.js, menu.js, progressbar.js, selectmenu.js, slider.js, spinner.js, tabs.js, tooltip.js
 * Copyright jQuery Foundation and other contributors; Licensed  */
@@ -16092,6 +16092,7 @@ return $.widget( "ui.sortable", $.ui.mouse, {
 		handle: false,
 		helper: "original",
 		items: "> *",
+		onRevertUseScrollParent: false,
 		opacity: false,
 		placeholder: false,
 		revert: false,
@@ -16560,18 +16561,22 @@ return $.widget( "ui.sortable", $.ui.mouse, {
 				axis = this.options.axis,
 				animation = {};
 
+			var offSetElement = this.options.onRevertUseScrollParent ?
+			  this.placeholder.scrollParent() :
+			  this.offsetParent;
+
 			if ( !axis || axis === "x" ) {
 				animation.left = cur.left - this.offset.parent.left - this.margins.left +
-					( this.offsetParent[ 0 ] === this.document[ 0 ].body ?
+					( offSetElement[ 0 ] === this.document[ 0 ].body ?
 						0 :
-						this.offsetParent[ 0 ].scrollLeft
+						offSetElement[ 0 ].scrollLeft
 					);
 			}
 			if ( !axis || axis === "y" ) {
 				animation.top = cur.top - this.offset.parent.top - this.margins.top +
-					( this.offsetParent[ 0 ] === this.document[ 0 ].body ?
+					( offSetElement[ 0 ] === this.document[ 0 ].body ?
 						0 :
-						this.offsetParent[ 0 ].scrollTop
+						offSetElement[ 0 ].scrollTop
 					);
 			}
 			this.reverting = true;

--- a/dist/jquery-ui.js
+++ b/dist/jquery-ui.js
@@ -16092,7 +16092,6 @@ return $.widget( "ui.sortable", $.ui.mouse, {
 		handle: false,
 		helper: "original",
 		items: "> *",
-		onRevertUseScrollParent: false,
 		opacity: false,
 		placeholder: false,
 		revert: false,
@@ -16101,6 +16100,7 @@ return $.widget( "ui.sortable", $.ui.mouse, {
 		scrollSpeed: 20,
 		scope: "default",
 		tolerance: "intersect",
+		withRevertUseScrollParent: false,
 		zIndex: 1000,
 
 		// Callbacks
@@ -16561,7 +16561,7 @@ return $.widget( "ui.sortable", $.ui.mouse, {
 				axis = this.options.axis,
 				animation = {};
 
-			var offsetElement = this.options.onRevertUseScrollParent ?
+			var offsetElement = this.options.withRevertUseScrollParent ?
 			  this.scrollParent :
 			  this.offsetParent;
 

--- a/tests/unit/sortable/common.js
+++ b/tests/unit/sortable/common.js
@@ -23,6 +23,7 @@ common.testWidget( "sortable", {
 		handle: false,
 		helper: "original",
 		items: "> *",
+		onRevertUseScrollParent: false,
 		opacity: false,
 		placeholder: false,
 		revert: false,

--- a/tests/unit/sortable/common.js
+++ b/tests/unit/sortable/common.js
@@ -23,7 +23,6 @@ common.testWidget( "sortable", {
 		handle: false,
 		helper: "original",
 		items: "> *",
-		onRevertUseScrollParent: false,
 		opacity: false,
 		placeholder: false,
 		revert: false,
@@ -32,6 +31,7 @@ common.testWidget( "sortable", {
 		scrollSpeed: 20,
 		scope: "default",
 		tolerance: "intersect",
+		withRevertUseScrollParent: false,
 		zIndex: 1000,
 
 		// Callbacks

--- a/ui/widgets/sortable.js
+++ b/ui/widgets/sortable.js
@@ -52,7 +52,6 @@ return $.widget( "ui.sortable", $.ui.mouse, {
 		handle: false,
 		helper: "original",
 		items: "> *",
-		onRevertUseScrollParent: false,
 		opacity: false,
 		placeholder: false,
 		revert: false,
@@ -61,6 +60,7 @@ return $.widget( "ui.sortable", $.ui.mouse, {
 		scrollSpeed: 20,
 		scope: "default",
 		tolerance: "intersect",
+		withRevertUseScrollParent: false,
 		zIndex: 1000,
 
 		// Callbacks
@@ -521,7 +521,7 @@ return $.widget( "ui.sortable", $.ui.mouse, {
 				axis = this.options.axis,
 				animation = {};
 
-			var offsetElement = this.options.onRevertUseScrollParent ?
+			var offsetElement = this.options.withRevertUseScrollParent ?
 			  this.scrollParent :
 			  this.offsetParent;
 

--- a/ui/widgets/sortable.js
+++ b/ui/widgets/sortable.js
@@ -521,22 +521,22 @@ return $.widget( "ui.sortable", $.ui.mouse, {
 				axis = this.options.axis,
 				animation = {};
 
-			var offSetElement = this.options.onRevertUseScrollParent ?
-			  this.placeholder.scrollParent() :
+			var offsetElement = this.options.onRevertUseScrollParent ?
+			  this.scrollParent :
 			  this.offsetParent;
 
 			if ( !axis || axis === "x" ) {
 				animation.left = cur.left - this.offset.parent.left - this.margins.left +
-					( offSetElement[ 0 ] === this.document[ 0 ].body ?
+					( offsetElement[ 0 ] === this.document[ 0 ].body ?
 						0 :
-						offSetElement[ 0 ].scrollLeft
+						offsetElement[ 0 ].scrollLeft
 					);
 			}
 			if ( !axis || axis === "y" ) {
 				animation.top = cur.top - this.offset.parent.top - this.margins.top +
-					( offSetElement[ 0 ] === this.document[ 0 ].body ?
+					( offsetElement[ 0 ] === this.document[ 0 ].body ?
 						0 :
-						offSetElement[ 0 ].scrollTop
+						offsetElement[ 0 ].scrollTop
 					);
 			}
 			this.reverting = true;

--- a/ui/widgets/sortable.js
+++ b/ui/widgets/sortable.js
@@ -52,6 +52,7 @@ return $.widget( "ui.sortable", $.ui.mouse, {
 		handle: false,
 		helper: "original",
 		items: "> *",
+		onRevertUseScrollParent: false,
 		opacity: false,
 		placeholder: false,
 		revert: false,
@@ -520,18 +521,22 @@ return $.widget( "ui.sortable", $.ui.mouse, {
 				axis = this.options.axis,
 				animation = {};
 
+			var offSetElement = this.options.onRevertUseScrollParent ?
+			  this.placeholder.scrollParent() :
+			  this.offsetParent;
+
 			if ( !axis || axis === "x" ) {
 				animation.left = cur.left - this.offset.parent.left - this.margins.left +
-					( this.offsetParent[ 0 ] === this.document[ 0 ].body ?
+					( offSetElement[ 0 ] === this.document[ 0 ].body ?
 						0 :
-						this.offsetParent[ 0 ].scrollLeft
+						offSetElement[ 0 ].scrollLeft
 					);
 			}
 			if ( !axis || axis === "y" ) {
 				animation.top = cur.top - this.offset.parent.top - this.margins.top +
-					( this.offsetParent[ 0 ] === this.document[ 0 ].body ?
+					( offSetElement[ 0 ] === this.document[ 0 ].body ?
 						0 :
-						this.offsetParent[ 0 ].scrollTop
+						offSetElement[ 0 ].scrollTop
 					);
 			}
 			this.reverting = true;


### PR DESCRIPTION
Added a new optional parameter `withRevertUseScrollParent` to `ui-sortable` to make sure that when it does the revert animation it uses the `scrollParent` instead of `offsetParent` to calculate the animation final position.

I spent some time trying to add some tests to the jquery repo, to test this new feature but it's hard to reproduce, it's only happening when the component is wrapper by the ps-scroller directive.